### PR TITLE
Fix jaffle-sl-template project to work with dbt-duckdb

### DIFF
--- a/models/marts/customers.sql
+++ b/models/marts/customers.sql
@@ -6,13 +6,13 @@ customers as (
 
 ),
 
-orders as (
+orders_table as (
 
     select * from {{ ref('orders') }}
 
 ),
 
-order_items as (
+order_items_table as (
 
     select * from {{ ref('order_items') }}
 ),
@@ -29,9 +29,9 @@ order_summary as (
         sum(order_items.product_price) as lifetime_spend_pretax,
         sum(orders.order_total) as lifetime_spend
 
-    from orders
+    from orders_table as orders
     
-    left join order_items on orders.order_id = order_items.order_id
+    left join order_items_table as order_items on orders.order_id = order_items.order_id
     
     group by 1
 

--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -6,7 +6,7 @@ orders as (
 
 ),
 
-order_items as (
+order_items_table as (
     
     select * from {{ ref('order_items')}}
 
@@ -23,7 +23,7 @@ order_items_summary as (
         sum(is_drink_item) as count_drink_items
 
 
-    from order_items
+    from order_items_table as order_items
 
     group by 1
 

--- a/packages.yml
+++ b/packages.yml
@@ -2,5 +2,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - package: calogica/dbt_date
-    version: [">=0.7.0", "<0.8.0"]
+    version: [">=0.8.0", "<0.9.0"]
     # <see https://github.com/calogica/dbt-date/releases/latest> for the latest version tag


### PR DESCRIPTION
This PR includes two fixes:

1. Update dbt_date package version to >= 0.8.0, < 0.9

duckdb support was added to this package dependency with version 0.80.

2. Update models to be compatible with duckdb

Some of the models throw errors when run with duckdb due to a
circular CTE reference. This appears to be due to how the ref()
is rendered in the compiled SQL, so you end up with the order_items
CTE selecting from order_items.

Rather than allow circular CTEs, this change simply renames the CTE
in question and aliases selects out of it in order to minimize the
scope of these changes.

If we determine the recursive CTE approach is better, or if there's
a way to enable that for duckdb only, we can always update.