### PR TITLE
Switch profile to snowflake in dbt_project.yml

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -6,7 +6,7 @@ version: "1.0.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.
-profile: "databricks"
+profile: "snowflake"
 require-dbt-version: ">=1.6.0rc2"
 
 # These configurations specify where dbt should look for different types of files.


### PR DESCRIPTION
The CI job for dbt build depends on the snowflake profile, but
somewhere along the line we switched snowflake out for databricks,
which leads to persistent CI failures.

This puts snowflake back in place for now. We might consider making
this an env_var() property so we can run CI for different profile
configs.
