### PR TITLE
Fixed deprecation warning

### DIFF
--- a/models/marts/customer360/orders.yml
+++ b/models/marts/customer360/orders.yml
@@ -120,11 +120,11 @@ metrics:
     type_params:
       measure: order_count
   - name: orders_fill_nulls_with_zero
-    description: Example metric colaescing null to zero. 
+    description: Example metric colaescing null to zero.
     label: Orders (Fill nulls with 0)
     type: simple
     type_params:
-      measure: 
+      measure:
         name: order_count
         fill_nulls_with: 0
         join_to_timespine: true
@@ -151,5 +151,6 @@ metrics:
     type: cumulative
     type_params:
       measure: order_count
-      window: 7 days
+      cumulative_type_params:
+        window: 7 days
 # // test


### PR DESCRIPTION
This fixes a deprecation warning that was being displayed during `dbt parse`:
```
Cumulative fields `type_params.window` and `type_params.grain_to_date` have been moved and will soon be deprecated. Please nest those values under `type_params.cumulative_type_params.window` and `type_params.cumulative_type_params.grain_to_date`. Metrics using old fields: ['orders_last_7_days']
```

auto-merge is on