### PR TITLE
Migrate dbt-date to GoDataDriven

### DIFF
--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,6 +1,6 @@
 packages:
-- package: dbt-labs/dbt_utils
-  version: 1.0.0
-- package: calogica/dbt_date
-  version: 0.8.1
-sha1_hash: f2bef868041b4f03296151f8be2969fc320a781a
+  - package: dbt-labs/dbt_utils
+    version: 1.0.0
+  - package: godatadriven/dbt_date
+    version: 0.8.1
+sha1_hash: 77a0b370fde67484f39622bdf18348f55266145d

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
-  - package: calogica/dbt_date
+  - package: godatadriven/dbt_date
     version: [">=0.8.0", "<0.9.0"]
     # <see https://github.com/calogica/dbt-date/releases/latest> for the latest version tag


### PR DESCRIPTION
Calogica's [dbt-date](https://github.com/calogica/dbt-date) package is no longer supported. Instead, GoDataDriven's [dbt-date](https://github.com/metaplane/dbt-date) package is now featured on the [dbt Package Hub](https://hub.getdbt.com/godatadriven/dbt_date/latest/). This PR migrates the dependency in this repo.