### PR TITLE
Pin GitHub Actions to specific SHAs (4 actions in 2 files)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   dbt-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/metrics_ci.yml
+++ b/.github/workflows/metrics_ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # actions/setup-python@v2
         with:
           python-version: '3.9.16'
 


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 2
- **Actions pinned**: 4

### 📝 Changes by file

#### `.github/workflows/metrics_ci.yml`

- 📌 `actions/checkout@v2` → `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # actions/checkout@v2`
- 📌 `actions/setup-python@v2` → `actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # actions/setup-python@v2`

#### `.github/workflows/ci.yml`

- 📌 `actions/checkout@v3` → `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3`
- 📌 `actions/setup-python@v4` → `actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # actions/setup-python@v4`

